### PR TITLE
add nil tet for getting gnavi api

### DIFF
--- a/spec/controllers/shops_controller_spec.rb
+++ b/spec/controllers/shops_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ShopsController, :type => :controller do
 
     it "should return data" do
       get :index
-      expect(assigns[:data]).should_not be_nil
+      expect(assigns[:data]).not_to eq(nil)
     end
   end
 end


### PR DESCRIPTION
現状、gnaviに問い合わせてnilではないということしか確認できません…
menu_nameによる検索の振り分けテストは保留とします。
