### PR TITLE
Replace noimage.png using JavaScript

### DIFF
--- a/app/views/shops/multi.html.erb
+++ b/app/views/shops/multi.html.erb
@@ -39,6 +39,13 @@
 
 <script>
 $(function(){
+  $(".item img").error(function() {
+    $(this).attr({
+      src: '/images/noimage.png',
+      alt: 'no image'
+    });
+  });
+
   $(".carousel-indicators li:first").addClass("active");
   $(".carousel-inner .item:first").addClass("active");
 


### PR DESCRIPTION
後藤さん、お願いします。

画像のURLがあっても404で返ってくるのは、ぐるなびで管理している画像の問題だと思われます。
404エラーが返る場合は/images/noimage.pngに差し替える処理を追加しました。
